### PR TITLE
Check and create parent directories

### DIFF
--- a/libusbcamera/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libusbcamera/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -314,6 +314,9 @@ public final class USBMonitor {
 		String fileName = Environment.getExternalStorageDirectory()+ "/USBCamera/failed_devices.txt";
 
 		File logFile = new File(fileName);
+		if(!logFile.getParentFile().exists()) {
+			logFile.getParentFile().mkdirs();
+		}
 		if(! logFile.exists()) {
 			try {
 				logFile.createNewFile();


### PR DESCRIPTION
Without explicitly checking for missing parent directors and creating them, the app won't run on my Android 7.0 Nvidia.