### PR TITLE
fix: fix FATAL EXCEPTION when Targeting S+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /captures
 .externalNativeBuild
 .tags*
+.cxx/

--- a/libuvc/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libuvc/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -165,13 +165,18 @@ public final class USBMonitor {
 	 * register BroadcastReceiver to monitor USB events
 	 * @throws IllegalStateException
 	 */
+	@SuppressLint("UnspecifiedImmutableFlag")
 	public synchronized void register() throws IllegalStateException {
 		if (destroyed) throw new IllegalStateException("already destroyed");
 		if (mPermissionIntent == null) {
 			if (DEBUG) XLogWrapper.i(TAG, "register:");
 			final Context context = mWeakContext.get();
 			if (context != null) {
-				mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), 0);
+				if (Build.VERSION.SDK_INT >= 23) {
+					mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
+				} else {
+					mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), 0);
+				}
 				final IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
 				// ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
 				filter.addAction(ACTION_USB_DEVICE_ATTACHED);


### PR DESCRIPTION
When setting targetSdk >= 31, PendingIntent must set FLAG_IMMUTABLE or FLAG_MUTABLE. If not, app will crash when call ```USBMonitor.register```.

Log looks like the below.

```
Caused by: java.lang.IllegalArgumentException: com.example.test: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
```