### PR TITLE
Fix no frames on format change

### DIFF
--- a/libuvc/src/main/jni/libuvc/src/stream.c
+++ b/libuvc/src/main/jni/libuvc/src/stream.c
@@ -990,6 +990,7 @@ static void _uvc_stream_callback(struct libusb_transfer *transfer) {
 		// pass through to following lines
 	case LIBUSB_TRANSFER_CANCELLED:
 	case LIBUSB_TRANSFER_ERROR:
+		libusb_clear_halt(strmh->devh->usb_devh, strmh->stream_if->bEndpointAddress);
 		UVC_DEBUG("not retrying transfer, status = %d", transfer->status);
 //		MARK("not retrying transfer, status = %d", transfer->status);
 //		_uvc_delete_transfer(transfer);


### PR DESCRIPTION
This code change fixes an issue where you get a black screen (no frames coming in) when changing the video format on the fly. The issue also sometimes happens when closing and starting the app. I was only able to reproduce this issue on one type of capture device (MS2130). Needs to be tested on more types of capture cards.