### PR TITLE
Fix crash on android 14

### DIFF
--- a/libuvc/src/main/java/com/jiangdg/usb/USBMonitor.java
+++ b/libuvc/src/main/java/com/jiangdg/usb/USBMonitor.java
@@ -177,7 +177,7 @@ public final class USBMonitor {
 					// avoid acquiring intent data failed in receiver on Android12
 					// when using PendingIntent.FLAG_IMMUTABLE
 					// because it means Intent can't be modified anywhere -- jiangdg/20220929
-					int PENDING_FLAG_IMMUTABLE = 1<<25;
+					int PENDING_FLAG_IMMUTABLE = 0x04000000;
 					mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PENDING_FLAG_IMMUTABLE);
 				} else {
 					mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), 0);

--- a/libuvc/src/main/java/com/jiangdg/usb/USBMonitor.java
+++ b/libuvc/src/main/java/com/jiangdg/usb/USBMonitor.java
@@ -66,8 +66,6 @@ public final class USBMonitor {
 
 	public static final String ACTION_USB_DEVICE_ATTACHED = "android.hardware.usb.action.USB_DEVICE_ATTACHED";
 
-	private static final int RECEIVER_NOT_EXPORTED = 4;
-
 	/**
 	 * openしているUsbControlBlock
 	 */
@@ -189,6 +187,8 @@ public final class USBMonitor {
 				filter.addAction(ACTION_USB_DEVICE_ATTACHED);
 				filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
 				if (Build.VERSION.SDK_INT >= 34) {
+					// RECEIVER_NOT_EXPORTED is required on Android 14
+					int RECEIVER_NOT_EXPORTED = 4;
 					context.registerReceiver(mUsbReceiver, filter, RECEIVER_NOT_EXPORTED);
 				} else {
 					context.registerReceiver(mUsbReceiver, filter);

--- a/libuvc/src/main/java/com/jiangdg/usb/USBMonitor.java
+++ b/libuvc/src/main/java/com/jiangdg/usb/USBMonitor.java
@@ -66,6 +66,8 @@ public final class USBMonitor {
 
 	public static final String ACTION_USB_DEVICE_ATTACHED = "android.hardware.usb.action.USB_DEVICE_ATTACHED";
 
+	private static final int RECEIVER_NOT_EXPORTED = 4;
+
 	/**
 	 * openしているUsbControlBlock
 	 */
@@ -186,7 +188,11 @@ public final class USBMonitor {
 				// ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
 				filter.addAction(ACTION_USB_DEVICE_ATTACHED);
 				filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-				context.registerReceiver(mUsbReceiver, filter);
+				if (Build.VERSION.SDK_INT >= 34) {
+					context.registerReceiver(mUsbReceiver, filter, RECEIVER_NOT_EXPORTED);
+				} else {
+					context.registerReceiver(mUsbReceiver, filter);
+				}
 			}
 			// start connection check
 			mDeviceCounts = 0;


### PR DESCRIPTION
In Android 14, registerReceiver fails because its now missing and extra flag. This PR fixes that behavior.

Tested on an Android 14 device.